### PR TITLE
Mobile Responsiveness for Testimonies

### DIFF
--- a/src/components/home/Card.tsx
+++ b/src/components/home/Card.tsx
@@ -8,12 +8,12 @@ interface componentProps {
 
 const Card = ({ name, quote }: componentProps) => {
   return (
-    <div className="mx-auto flex w-2/3 flex-col place-items-center justify-evenly rounded-xl bg-white p-8 shadow-xl">
+    <div className="mx-auto my-8 flex w-2/3 flex-col place-items-center justify-evenly rounded-xl bg-white p-3 shadow-xl lg:p-8">
       <div className="place-items-center p-1">
-        <Image src={quoteIcon} className="w-3/4" alt="quoteIcon" />
+        <Image src={quoteIcon} className="w-1/2 lg:w-3/4" alt="quoteIcon" />
       </div>
-      <div className="p-5 md:text-left">{quote}</div>
-      <div className="p-1 font-bold">{name}</div>
+      <div className="p-5 text-left text-sm lg:text-base">{quote}</div>
+      <div className="p-1 text-sm font-bold lg:text-base">{name}</div>
     </div>
   );
 };

--- a/src/components/home/Testimony.tsx
+++ b/src/components/home/Testimony.tsx
@@ -6,9 +6,9 @@ const Testimony = () => {
   return (
     <div className="flex w-full flex-col bg-ula-blue-highlight p-8">
       <Header text="Words from the ULA Community" />
-      <div className="mx-auto flex w-3/4 flex-col justify-center">
+      <div className="mx-auto flex flex-col justify-center lg:w-3/4">
         <p className="my-8 text-center text-4xl font-semibold">Former ULAs</p>
-        <div className="grid grid-cols-2">
+        <div className="grid grid-cols-1 lg:grid-cols-2">
           {testimonies.slice(0, 2).map(({ name, quote }, index) => (
             <Card key={index} name={name} quote={quote} />
           ))}
@@ -16,7 +16,7 @@ const Testimony = () => {
         <p className="my-8 pt-6 text-center text-4xl font-semibold">
           Current ULAs
         </p>
-        <div className="grid grid-cols-2">
+        <div className="grid grid-cols-1 lg:grid-cols-2">
           {testimonies.slice(2, 4).map(({ name, quote }, index) => (
             <Card key={index} name={name} quote={quote} />
           ))}
@@ -24,7 +24,7 @@ const Testimony = () => {
         <p className="my-8 pt-6 text-center text-4xl font-semibold">
           Students on ULA
         </p>
-        <div className="grid grid-cols-2">
+        <div className="grid grid-cols-1 lg:grid-cols-2">
           {testimonies.slice(4, 6).map(({ name, quote }, index) => (
             <Card key={index} name={name} quote={quote} />
           ))}


### PR DESCRIPTION
<img width="385" height="832" alt="image" src="https://github.com/user-attachments/assets/ac21d24c-8bc9-4c93-a3b2-208bb8f14468" />
<img width="385" height="840" alt="image" src="https://github.com/user-attachments/assets/ad4e7a2c-a6f3-48bd-8b69-3dedd4b4864c" />
<img width="384" height="839" alt="image" src="https://github.com/user-attachments/assets/dbba3e49-7c56-4670-9ce9-26d8159cf27c" />

I forgot to push these changes to my previous PR regarding the testimony mapping. These changes reflect the mobile responsiveness that was discussed during this week's meeting.