### PR TITLE
Mobilizing Our Goals Section

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ interface headerProps {
 
 const Header = ({ text }: headerProps) => {
   return (
-    <div className="text-center text-5xl font-bold text-ula-blue-primary">
+    <div className="text-center text-3xl font-bold text-ula-blue-primary md:text-4xl lg:text-5xl">
       {text}
     </div>
   );

--- a/src/components/about/OurGoals.tsx
+++ b/src/components/about/OurGoals.tsx
@@ -6,7 +6,7 @@ const OurGoals = () => {
   return (
     <div className="py-8">
       <Header text="Our Goals" />
-      <div className="flex w-full justify-evenly pt-6">
+      <div className="flex w-full flex-wrap justify-evenly pt-6 md:flex-nowrap">
         {ourGoalsCard.map(({ image, text }, index) => (
           <OurGoalsCard key={index} image={image} text={text} />
         ))}

--- a/src/components/about/OurGoals.tsx
+++ b/src/components/about/OurGoals.tsx
@@ -6,7 +6,7 @@ const OurGoals = () => {
   return (
     <div className="py-8">
       <Header text="Our Goals" />
-      <div className="flex w-full flex-wrap justify-evenly pt-6 md:flex-nowrap">
+      <div className="flex w-full flex-wrap justify-evenly md:pt-6 lg:flex-nowrap">
         {ourGoalsCard.map(({ image, text }, index) => (
           <OurGoalsCard key={index} image={image} text={text} />
         ))}

--- a/src/components/about/OurGoalsCard.tsx
+++ b/src/components/about/OurGoalsCard.tsx
@@ -8,7 +8,7 @@ type ourGoalsProps = {
 
 const OurGoalsCard = ({ image, text }: ourGoalsProps) => {
   return (
-    <div className="mx-8 flex w-1/4 flex-col items-center justify-center gap-y-4 border-y-4 border-ula-yellow-primary py-8 text-center text-xl font-medium">
+    <div className="mx-8 my-8 flex min-h-[283px] w-1/4 min-w-[245px] flex-col items-center justify-center gap-y-4 border-y-4 border-ula-yellow-primary text-center text-xl font-medium md:py-8">
       <Image src={image} alt="logo" />
       <div className="px-8">{text}</div>
     </div>

--- a/src/components/about/OurGoalsCard.tsx
+++ b/src/components/about/OurGoalsCard.tsx
@@ -9,7 +9,7 @@ type ourGoalsProps = {
 const OurGoalsCard = ({ image, text }: ourGoalsProps) => {
   return (
     <div className="mx-8 my-8 flex min-h-[283px] w-1/4 min-w-[245px] flex-col items-center justify-center gap-y-4 border-y-4 border-ula-yellow-primary text-center text-xl font-medium md:py-8">
-      <Image src={image} alt="logo" />
+      <Image src={image} alt="logo" width={68} height={68} />
       <div className="px-8">{text}</div>
     </div>
   );

--- a/src/components/about/Progress.tsx
+++ b/src/components/about/Progress.tsx
@@ -4,7 +4,7 @@ import CountUp from "react-countup";
 
 const Progress = () => {
   return (
-    <div className="my-8 flex w-full flex-col items-center justify-center bg-ula-blue-primary py-6">
+    <div className="mb-8 flex w-full flex-col items-center justify-center bg-ula-blue-primary py-6">
       <p className="flex w-full justify-center p-8 text-center font-bold text-white sm:text-4xl">
         The UCR CS ULA program started in Fall 2021. Since then we have…
       </p>


### PR DESCRIPTION
<img width="697" height="908" alt="Screenshot 2025-07-27 at 11 20 07 AM" src="https://github.com/user-attachments/assets/7f22c6f4-e523-40b5-aca7-5b5a83ca7b3c" />

wrapping seems to be correct, but I wasn't sure how to edit the space in between the yellow borderlines when updating the wrapping for mobile responsiveness.