### PR TITLE
Added mobile responsiveness for landing page

### DIFF
--- a/src/components/home/Landing.tsx
+++ b/src/components/home/Landing.tsx
@@ -11,7 +11,7 @@ const Landing = () => {
         objectFit="cover"
       />
       <div className="absolute flex h-full w-full items-center justify-center">
-        <div className="flex h-1/3 w-1/3 place-items-center justify-center border-b-4 border-ula-yellow-primary text-center text-6xl font-bold text-white">
+        <div className="flex h-1/3 w-1/3 place-items-center justify-center border-b-4 border-ula-yellow-primary text-center text-4xl font-bold text-white xl:text-6xl">
           UCR CSE's Undergraduate Learning Assistants
         </div>
       </div>


### PR DESCRIPTION
On desktop:
<img width="2880" height="1380" alt="image" src="https://github.com/user-attachments/assets/b385f7ef-abb4-4eae-a835-9c0e2717a42c" />


On mobile:
<img width="756" height="1336" alt="image" src="https://github.com/user-attachments/assets/6c43d673-d33a-49c1-adc4-f9ff7f3f57d3" />

Closes #89 