### PR TITLE
Animated 'Our Goals' component

### DIFF
--- a/src/components/about/OurGoals.tsx
+++ b/src/components/about/OurGoals.tsx
@@ -16,10 +16,28 @@ const OurGoals = () => {
         <Header text="Our Goals" />
       </motion.div>
 
-      <div className="flex w-full flex-wrap justify-evenly md:pt-6 lg:flex-nowrap">
+      {/* <div className="flex w-full flex-wrap justify-evenly md:pt-6 lg:flex-nowrap">
         {ourGoalsCard.map(({ image, text }, index) => (
           <motion.div
             className="flex w-[45%] justify-center"
+            key={index}
+            initial={{ opacity: 0, y: 40, scale: 0.9 }}
+            whileInView={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{
+              duration: 0.6,
+              ease: "easeOut",
+              delay: index * 0.2,
+            }}
+          >
+            <OurGoalsCard image={image} text={text} />
+          </motion.div>
+        ))}
+      </div> */}
+
+      <div className="flex w-full flex-wrap justify-evenly md:flex-nowrap md:pt-6">
+        {ourGoalsCard.map(({ image, text }, index) => (
+          <motion.div
+            className="flex justify-center"
             key={index}
             initial={{ opacity: 0, y: 40, scale: 0.9 }}
             whileInView={{ opacity: 1, y: 0, scale: 1 }}

--- a/src/components/about/OurGoals.tsx
+++ b/src/components/about/OurGoals.tsx
@@ -16,24 +16,6 @@ const OurGoals = () => {
         <Header text="Our Goals" />
       </motion.div>
 
-      {/* <div className="flex w-full flex-wrap justify-evenly md:pt-6 lg:flex-nowrap">
-        {ourGoalsCard.map(({ image, text }, index) => (
-          <motion.div
-            className="flex w-[45%] justify-center"
-            key={index}
-            initial={{ opacity: 0, y: 40, scale: 0.9 }}
-            whileInView={{ opacity: 1, y: 0, scale: 1 }}
-            transition={{
-              duration: 0.6,
-              ease: "easeOut",
-              delay: index * 0.2,
-            }}
-          >
-            <OurGoalsCard image={image} text={text} />
-          </motion.div>
-        ))}
-      </div> */}
-
       <div className="flex w-full flex-wrap justify-evenly md:flex-nowrap md:pt-6">
         {ourGoalsCard.map(({ image, text }, index) => (
           <motion.div

--- a/src/components/about/OurGoals.tsx
+++ b/src/components/about/OurGoals.tsx
@@ -3,7 +3,7 @@
 import OurGoalsCard from "@/components/about/OurGoalsCard";
 import Header from "@/components/Header";
 import { ourGoalsCard } from "@/data/OurGoalsCards";
-import { motion } from "framer-motion";
+import { motion } from "motion/react";
 
 const OurGoals = () => {
   return (

--- a/src/components/about/OurGoals.tsx
+++ b/src/components/about/OurGoals.tsx
@@ -1,14 +1,36 @@
+"use client";
+
 import OurGoalsCard from "@/components/about/OurGoalsCard";
 import Header from "@/components/Header";
 import { ourGoalsCard } from "@/data/OurGoalsCards";
+import { motion } from "framer-motion";
 
 const OurGoals = () => {
   return (
     <div className="py-8">
-      <Header text="Our Goals" />
+      <motion.div
+        initial={{ opacity: 0, x: -50 }}
+        whileInView={{ opacity: 1, x: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+      >
+        <Header text="Our Goals" />
+      </motion.div>
+
       <div className="flex w-full flex-wrap justify-evenly md:pt-6 lg:flex-nowrap">
         {ourGoalsCard.map(({ image, text }, index) => (
-          <OurGoalsCard key={index} image={image} text={text} />
+          <motion.div
+            className="flex w-[45%] justify-center"
+            key={index}
+            initial={{ opacity: 0, y: 40, scale: 0.9 }}
+            whileInView={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{
+              duration: 0.6,
+              ease: "easeOut",
+              delay: index * 0.2,
+            }}
+          >
+            <OurGoalsCard image={image} text={text} />
+          </motion.div>
         ))}
       </div>
     </div>

--- a/src/components/about/OurGoalsCard.tsx
+++ b/src/components/about/OurGoalsCard.tsx
@@ -8,9 +8,9 @@ type ourGoalsProps = {
 
 const OurGoalsCard = ({ image, text }: ourGoalsProps) => {
   return (
-    <div className="mx-8 my-8 flex min-h-[283px] w-1/4 min-w-[245px] flex-col items-center justify-center gap-y-4 border-y-4 border-ula-yellow-primary text-center text-xl font-medium md:py-8">
-      <Image src={image} alt="logo" width={68} height={68} />
-      <div className="px-8">{text}</div>
+    <div className="m-8 flex w-full flex-col items-center justify-center gap-y-4 border-y-4 border-ula-yellow-primary py-8 text-center text-xl font-medium">
+      <Image src={image} alt="logo" className="w-1/4" />
+      <div className="text-sm md:px-4 md:text-lg">{text}</div>
     </div>
   );
 };


### PR DESCRIPTION
<img width="952" height="901" alt="Screenshot 2025-08-03 185258" src="https://github.com/user-attachments/assets/ae84fb62-445c-47cf-9ece-41452dcd9d8f" />


-Implemented scroll-triggered animations for the OurGoals component
-The section header now fades in and slides in from the left when scrolled into view.
-Each card fades in, slides up, and scales from 90%(0.9) to 100%(1) size, staggered with a delay based on its index to create a sequential entrance effect.
-Used className="flex w-[45%] justify-center" on the card wrappers to maintain the original card layout (2 cards side-by-side and 1 centered below on smaller screens).
ps. the attached image is for smaller screens, let me know if another layout is needed. AND I used a little AI to understand the structure in general (like where to place the motion div tags) cuz it was a little confusing at first so let me know if something looks wonky :| 

If this utility setup seems redundant or there's a better way to match the original layout, or if any of the animations feel too much, let me know and I'll be happy to cleanup/simplify further ! 

