### PR TITLE
Complete & Mobilize Questions Section

### DIFF
--- a/src/components/home/InfoButton.tsx
+++ b/src/components/home/InfoButton.tsx
@@ -12,10 +12,10 @@ interface infoButtonProps {
 const InfoButton = ({ icon, text, link }: infoButtonProps) => {
   return (
     <Link href={link}>
-      <div className="m-4 flex w-2/5 items-center justify-between px-6 py-5 shadow-lg">
-        <div className="flex items-center gap-3">
+      <div className="m-4 flex min-w-[380px] gap-8 px-6 py-5 shadow-lg">
+        <div className="flex gap-5">
           <Image src={icon} alt="icon" className="h-8 w-8" />
-          <p className="text-lg">{text}</p>
+          <p className="whitespace-nowrap text-lg">{text}</p>
         </div>
 
         <Image src={arrow} alt="arrow" className="ml-auto" />

--- a/src/components/home/Questions.tsx
+++ b/src/components/home/Questions.tsx
@@ -1,12 +1,19 @@
 import InfoButtonHeader from "@/components/home/InfoButtonHeader";
 import blueBook from "@/public/home/blueBook.svg";
 import InfoButton from "@/components/home/InfoButton";
+import baselinePeople from "@/public/home/baselinePeople.svg";
 
 const Questions = () => {
   return (
-    <div className="">
-      <InfoButtonHeader text="What courses can I get help with?" />
-      <InfoButton icon={blueBook} text="Browse Courses" link="/about" />
+    <div className="flex flex-col justify-evenly px-2 pt-8 md:flex-row">
+      <div className="min-w-[392px] md:w-2/5">
+        <InfoButtonHeader text="What courses can I get help with?" />
+        <InfoButton icon={blueBook} text="Browse Courses" link="/about" />
+      </div>
+      <div className="min-w-[392px] md:w-2/5">
+        <InfoButtonHeader text="Who are the ULAs?" />
+        <InfoButton icon={baselinePeople} text="Meet the ULAs" link="/ula" />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Added "Who are ULAs" Info Button Header and "Meet the ULAs" Info Button, and mobilized for mobile use. There is a small issue when decreasing the window size where the "What courses can I get help with?" Info Button Header wraps onto a different line and putting the "Browse Courses" Button onto a different line, making the section look a bit uneven (as shown in the last screenshot). Any advice would be appreciated on how to fix this.

Fixes Issue #87 
<img width="1552" height="908" alt="Screenshot 2025-08-03 at 9 44 36 AM" src="https://github.com/user-attachments/assets/0259b0f2-62e5-453b-921b-1d7ef1bedde0" />
<img width="686" height="908" alt="Screenshot 2025-08-03 at 9 44 53 AM" src="https://github.com/user-attachments/assets/6978c1c3-658c-4ff8-9453-893ab608ace8" />
<img width="1097" height="908" alt="Screenshot 2025-08-03 at 9 45 13 AM" src="https://github.com/user-attachments/assets/e90772c3-f33e-46f2-83cf-9a9099c2e57c" />
