### PR TITLE
Animating Testimony Cards

### DIFF
--- a/src/components/home/Card.tsx
+++ b/src/components/home/Card.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { motion } from "motion/react";
 import Image from "next/image";
 import quoteIcon from "@/public/home/quote.svg";
 
@@ -8,13 +11,19 @@ interface componentProps {
 
 const Card = ({ name, quote }: componentProps) => {
   return (
-    <div className="mx-auto my-8 flex w-2/3 flex-col place-items-center justify-evenly rounded-xl bg-white p-3 shadow-xl lg:p-8">
-      <div className="place-items-center p-1">
-        <Image src={quoteIcon} className="w-1/2 lg:w-3/4" alt="quoteIcon" />
+    <motion.div
+      whileHover={{ scale: 1.05 }}
+      transition={{ duration: 0.5 }}
+      className=""
+    >
+      <div className="mx-auto my-4 flex w-2/3 flex-col place-items-center justify-evenly rounded-xl bg-white p-3 shadow-xl lg:h-full lg:pb-8 lg:pl-8 lg:pr-8">
+        <div className="place-items-center p-1">
+          <Image src={quoteIcon} className="w-1/2 lg:w-3/4" alt="quoteIcon" />
+        </div>
+        <div className="p-5 text-left text-sm lg:text-base">{quote}</div>
+        <div className="p-1 text-sm font-bold lg:text-base">{name}</div>
       </div>
-      <div className="p-5 text-left text-sm lg:text-base">{quote}</div>
-      <div className="p-1 text-sm font-bold lg:text-base">{name}</div>
-    </div>
+    </motion.div>
   );
 };
 export default Card;

--- a/src/components/home/Testimony.tsx
+++ b/src/components/home/Testimony.tsx
@@ -13,7 +13,7 @@ const Testimony = () => {
             <Card key={index} name={name} quote={quote} />
           ))}
         </div>
-        <p className="my-8 pt-6 text-center text-4xl font-semibold">
+        <p className="my-8 pt-8 text-center text-4xl font-semibold">
           Current ULAs
         </p>
         <div className="grid grid-cols-1 lg:grid-cols-2">
@@ -21,7 +21,7 @@ const Testimony = () => {
             <Card key={index} name={name} quote={quote} />
           ))}
         </div>
-        <p className="my-8 pt-6 text-center text-4xl font-semibold">
+        <p className="my-8 pt-8 text-center text-4xl font-semibold">
           Students on ULA
         </p>
         <div className="grid grid-cols-1 lg:grid-cols-2">


### PR DESCRIPTION
I decided to animate the Testimony cards with a simple expand upon hover, but open to any feedback on different designs. I was able to adjust it to work for both laptop and mobile versions. 

The only small issue is in the last row of cards (Students on ULA row), I wasn't sure how to move the cards further up so it wouldn't be so close to the bottom of the blue background. I put included a screenshot

Fixes Issue #102 

<img width="972" height="908" alt="Screenshot 2025-08-17 at 11 06 33 AM" src="https://github.com/user-attachments/assets/9dccb88a-f4a9-4de5-aa93-bdda3ad658a8" />
<img width="1552" height="908" alt="Screenshot 2025-08-17 at 11 07 03 AM" src="https://github.com/user-attachments/assets/0fc39ae8-b396-417e-9271-ef90373b576d" />
<img width="1552" height="908" alt="Screenshot 2025-08-17 at 11 07 12 AM" src="https://github.com/user-attachments/assets/235c2276-dd61-4f4f-84cc-dbd367219b80" />
