### PR TITLE
Animated Location on Home Page

### DIFF
--- a/src/components/home/Location.tsx
+++ b/src/components/home/Location.tsx
@@ -10,7 +10,6 @@ const item = {
 };
 
 const container = {
-  hidden: {},
   show: { transition: { staggerChildren: 0.15 } },
 };
 
@@ -20,7 +19,7 @@ const Location = () => {
       variants={container}
       initial="hidden"
       whileInView="show"
-      viewport={{ once: false, amount: 0.3 }}
+      viewport={{ amount: 0.3 }}
       className="flex w-full flex-col items-center justify-evenly bg-ula-blue-primary md:flex-row"
     >
       <div className="flex flex-col items-center gap-8 px-8 pb-4 pt-8 md:w-2/5 md:pb-8">


### PR DESCRIPTION
Added scroll-triggered animations to Location.tsx . Text and buttons fade/slide up with stagger, and the map slides in from the left. Animations replay on every scroll into view. Current timing: stagger=0.15, duration=0.9, amount=0.3. Let me know if anything needs adjustment, I'll be happy to!
Ps. I learnt the variants pattern (reusing the "container and item" blocks) with some AI help, so if anything looks off or you’d prefer a different approach, let me know.

<img width="931" height="900" alt="Screenshot 2025-08-18 065732" src="https://github.com/user-attachments/assets/18ba1b0f-28aa-4f7b-90b1-2a48a0d57c05" />