### PR TITLE
Add animations for Professor section Part 2

### DIFF
--- a/src/components/about/Professor.tsx
+++ b/src/components/about/Professor.tsx
@@ -22,7 +22,7 @@ const Professor = () => {
       <motion.div
         initial={{ x: -100 }}
         whileInView={{ x: 0 }}
-        transition={{ duration: 1.4 }}
+        transition={{ duration: 1.0 }}
       >
         <FadeIn>
           <Image
@@ -37,7 +37,7 @@ const Professor = () => {
         <motion.div
           initial={{ x: 100 }}
           whileInView={{ x: 0 }}
-          transition={{ duration: 1.4 }}
+          transition={{ duration: 1.0 }}
         >
           <FadeIn>
             <p className="font-xl text-left text-lg text-black xl:text-2xl">
@@ -52,7 +52,7 @@ const Professor = () => {
         <motion.div
           initial={{ y: 45 }}
           whileInView={{ y: 0 }}
-          transition={{ duration: 1.4 }}
+          transition={{ duration: 1.0 }}
         >
           <FadeIn>
             <p className="font-xs mt-2 text-right font-semibold text-black xl:text-xl">


### PR DESCRIPTION
Added slide from left animation to professor's photo, slide from right animation to quote and slide up animation to name. Made Professor's name semibold to match the figma's screenshot. Please view local website to see the animations.

Fixes Issue #132 
<img width="1552" height="908" alt="Screenshot 2025-08-23 at 10 31 14 AM" src="https://github.com/user-attachments/assets/35f87612-9aec-421d-b89f-9aee793cde05" />
