### PR TITLE
Animated images: slide-in from left with staggered delays

### DIFF
--- a/src/components/home/Images.tsx
+++ b/src/components/home/Images.tsx
@@ -5,21 +5,25 @@ import ulaPic2 from "@/public/home/ulaPic2.webp";
 import Image from "next/image";
 import { motion } from "motion/react";
 
+const imageAnimation = (delay = 0) => ({
+  initial: { opacity: 0, x: -20 },
+  whileInView: { opacity: 1, x: 0 },
+  transition: { duration: 0.6, delay },
+});
+
 const Images = () => {
   return (
     <div className="flex flex-col place-items-center gap-8 py-12">
       <div className="w-1/2 border-b-2 border-ula-blue-primary md:border-b-4" />
-      <motion.div
-        initial={{ opacity: 0 }}
-        whileInView={{ opacity: 1 }}
-        transition={{
-          duration: 1.2,
-        }}
-        className="flex w-5/6 flex-col justify-center gap-8 md:w-1/3 md:flex-row"
-      >
-        <Image src={ulaPic1} alt="Ula Picture 1" />
-        <Image src={ulaPic2} alt="Ula Picture 2" />
-      </motion.div>
+      <div className="flex w-5/6 flex-col justify-center gap-8 md:w-1/3 md:flex-row">
+        <motion.div {...imageAnimation(0.3)}>
+          <Image src={ulaPic1} alt="Ula Picture 1" />
+        </motion.div>
+
+        <motion.div {...imageAnimation(0.4)}>
+          <Image src={ulaPic2} alt="Ula Picture 2" />
+        </motion.div>
+      </div>
     </div>
   );
 };

--- a/src/components/home/Images.tsx
+++ b/src/components/home/Images.tsx
@@ -15,12 +15,12 @@ const Images = () => {
   return (
     <div className="flex flex-col place-items-center gap-8 py-12">
       <div className="w-1/2 border-b-2 border-ula-blue-primary md:border-b-4" />
-      <div className="flex w-5/6 flex-col justify-center gap-8 md:w-1/3 md:flex-row">
-        <motion.div {...imageAnimation(0.3)}>
+      <div className="flex w-5/6 max-w-5xl flex-col justify-center gap-8 md:flex-row">
+        <motion.div className="md:w-1/2" {...imageAnimation(0.3)}>
           <Image src={ulaPic1} alt="Ula Picture 1" />
         </motion.div>
 
-        <motion.div {...imageAnimation(0.4)}>
+        <motion.div className="md:w-1/2" {...imageAnimation(0.4)}>
           <Image src={ulaPic2} alt="Ula Picture 2" />
         </motion.div>
       </div>


### PR DESCRIPTION
Hey! 
For this issue, I implemented animation so the two images in the section slide in from the left with staggered delays (0.3s then 0.4s), following the same style used in the “Help in Courses” section which I used for reference. Let me know if you’d like me to adjust the delay timing or make any other tweaks, I’ll be happy to!
Ps. below I've attached what this looks like on md as well as lg screen orientation.

https://github.com/user-attachments/assets/403821ac-8c98-4c37-985d-6bda003c23c3


https://github.com/user-attachments/assets/ef9b383c-be2a-409c-a32a-604fc52a2b87

