### PR TITLE
Boweser Side Image Loading Bug

### DIFF
--- a/src/components/about/Professor.tsx
+++ b/src/components/about/Professor.tsx
@@ -29,6 +29,7 @@ const Professor = () => {
             src={professorImage}
             alt="Professor Watkinson Medina"
             className="font-sm mb-4 w-full rounded-md xl:w-3/4"
+            priority
           />
         </FadeIn>
       </motion.div>


### PR DESCRIPTION
On firefox it doesn't show anything:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/a892fa78-df0a-4481-a8d2-6ce2ce51ec06" />
On chrome it shows up:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/f3918421-ba43-4358-9069-f58b8314572e" />
When I add priority and run it locally it shows up on firefox:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/5d578cf1-4844-4782-882c-331ae937ae28" />

I think the issue depends on the browser you use since it loads fine on chrome but I use firefox usually so it doesn't load for me.

Also another interesting thing:

https://github.com/user-attachments/assets/6dea88cc-151b-4ce4-b935-d5d63085098e

the image is there but it isn't loading correctly on firefox fore some reason
